### PR TITLE
Stop back-ticks showing inside of in-line code styles

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,16 +11,26 @@ module.exports = {
 	theme: {
 		extend: {
 			typography: {
+				DEFAULT: {
+					css: {
+						'code::before': {
+							content: '""'
+						},
+						'code::after': {
+							content: '""'
+						}
+					}
+				},
 				quoteless: {
 					css: {
 						"blockquote p:first-of-type::before": { content: "none" },
 						"blockquote p:first-of-type::after": { content: "none" },
 					},
-				},
+				}
 			},
 			fontFamily: {
-				sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
-				display: ["var(--font-calsans)"],
+				sans: ["var(--font-instrument-sans)"],
+				mono: ["var(--font-fragment-mono)"],
 			},
 			backgroundImage: {
 				"gradient-radial":
@@ -92,7 +102,7 @@ module.exports = {
 					},
 				},
 			},
-		},
+		}
 	},
 	plugins: [
 		require("@tailwindcss/typography"),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,19 +18,19 @@ module.exports = {
 						},
 						'code::after': {
 							content: '""'
-						}
-					}
+						},
+					},
 				},
 				quoteless: {
 					css: {
 						"blockquote p:first-of-type::before": { content: "none" },
 						"blockquote p:first-of-type::after": { content: "none" },
 					},
-				}
+				},
 			},
 			fontFamily: {
-				sans: ["var(--font-instrument-sans)"],
-				mono: ["var(--font-fragment-mono)"],
+				sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
+				display: ["var(--font-calsans)"],
 			},
 			backgroundImage: {
 				"gradient-radial":


### PR DESCRIPTION
Stop back-ticks showing inside of in-line code styles.

Changed the tailwind config file using this comment: https://github.com/tailwindlabs/tailwindcss-typography/issues/18