### PR TITLE
fix missing .com in header.tsx for twitter

### DIFF
--- a/app/projects/[slug]/header.tsx
+++ b/app/projects/[slug]/header.tsx
@@ -67,7 +67,7 @@ export const Header: React.FC<Props> = ({ project, views }) => {
 								views,
 							)}
 						</span>
-						<Link target="_blank" href="https://twitter/chronark_">
+						<Link target="_blank" href="https://twitter.com/chronark_">
 							<Twitter
 								className={`w-6 h-6 duration-200 hover:font-medium ${
 									isIntersecting


### PR DESCRIPTION
Nice Page!
I saw, your linking in the header is broke with Twitter on line 70 in the header.tsx.

Have a nice day.
