### PR TITLE
small fixes for mobile

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -46,7 +46,7 @@ export default function Example() {
 									{s.icon}
 								</span>{" "}
 								<div className="z-10 flex flex-col items-center">
-									<span className="text-xl font-medium duration-150 lg:text-3xl text-zinc-200 group-hover:text-white font-display">
+									<span className="lg:text-xl font-medium duration-150 xl:text-3xl text-zinc-200 group-hover:text-white font-display">
 										{s.handle}
 									</span>
 									<span className="mt-4 text-sm text-center duration-1000 text-zinc-400 group-hover:text-zinc-200">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
 	return (
 		<div className="flex flex-col items-center justify-center w-screen h-screen overflow-hidden bg-gradient-to-tl from-black via-zinc-600/20 to-black">
 			<nav className="my-16 animate-fade-in">
-				<ul className="flex items-center justify-center gap-4">
+				<ul className="flex flex-wrap items-center justify-center gap-4">
 					{navigation.map((item) => (
 						<Link
 							key={item.href}
@@ -34,7 +34,7 @@ export default function Home() {
 
 			<div className="hidden w-screen h-px animate-glow md:block animate-fade-right bg-gradient-to-r from-zinc-300/0 via-zinc-300/50 to-zinc-300/0" />
 			<div className="my-16 text-center animate-fade-in">
-				<h2 className="text-sm text-zinc-500 ">
+				<h2 className="text-sm text-zinc-500 mx-6">
 					Hi, my name is Andreas, I'm building serverless and open source
 					solutions at{" "}
 					<Link
@@ -45,8 +45,8 @@ export default function Home() {
 						Upstash
 					</Link>
 
-					<br />
-					and working on{" "}
+					
+					<wbr /> and working on{" "}
 					<Link
 						target="_blank"
 						href="https://unkey.dev"

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -40,7 +40,7 @@ export default async function ProjectsPage() {
 	return (
 		<div className="relative pb-16">
 			<Navigation />
-			<div className="px-6 pt-16 mx-auto space-y-8 max-w-7xl lg:px-8 md:space-y-16 md:pt-24 lg:pt-32">
+			<div className="px-6 pt-20 mx-auto space-y-8 max-w-7xl lg:px-8 md:space-y-16 md:pt-24 lg:pt-32">
 				<div className="max-w-2xl mx-auto lg:mx-0">
 					<h2 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
 						Projects


### PR DESCRIPTION
Firstly, thank you very much for building this template - it's a game changer and truly the best portfolio style template site I've seen. I'd like to share a few small changes I made to the landing pages for home, contact, and projects that I found made mobile experiences a little better.

Home:

- on some mobile devices, the text is very close to overflowing on the x axis and the breaks don't look clean. To alleviate this, I added mx-6 for the body of text and changed a break tag to a word break tag.
- I also added flex-wrap to the navigation buttons at the top. I found that for my own project, once I added a few more buttons for additional landing pages they were overflowing on the x axis on mobile, so I added flex-wrap to fix that for future developers expanding past the template.

**after the fix**
![Screenshot 2023-08-20 at 23 11 44](https://github.com/chronark/chronark.com/assets/54906363/3f91a78f-5706-41cd-a4d7-deaf6710ecaa)
![Screenshot 2023-08-20 at 23 11 46](https://github.com/chronark/chronark.com/assets/54906363/1340e904-6e98-4fe3-ab12-4d4de337302e)

Projects:

- All I changed here was the padding top from pt-16 to pt-20 to give the "Projects" heading a little more breathing room and fix the overlap of the nav bar before any scrolling that was occuring.

**before the fix, you can see the top of the P is being cut off**
![Screenshot 2023-08-20 at 23 07 41](https://github.com/chronark/chronark.com/assets/54906363/1c3bd205-4143-417d-9554-e673f542cb93)
![Screenshot 2023-08-20 at 23 07 44](https://github.com/chronark/chronark.com/assets/54906363/bab9ae35-1c93-42e1-bc8b-541af23c2acf)

Contact:

- On some smaller mobile devices and tablets, the size of the font for the handles on the contact boxes were overflowing. To fix this, I just changed the break points.

Thanks again for building this and taking into consideration my small changes!