### PR TITLE
add padding to title for descenders

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
         className="absolute inset-0 -z-10 animate-fade-in"
         quantity={100}
       />
-      <h1 className="z-10 text-4xl text-transparent duration-1000 bg-white cursor-default text-edge-outline animate-title font-display sm:text-6xl md:text-9xl whitespace-nowrap bg-clip-text ">
+      <h1 className="pb-3.5 pr-0.5 z-10 text-4xl text-transparent duration-1000 bg-white cursor-default text-edge-outline animate-title font-display sm:text-6xl md:text-9xl whitespace-nowrap bg-clip-text ">
         chronark
       </h1>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
         className="absolute inset-0 -z-10 animate-fade-in"
         quantity={100}
       />
-      <h1 className="pb-3.5 pr-0.5 z-10 text-4xl text-transparent duration-1000 bg-white cursor-default text-edge-outline animate-title font-display sm:text-6xl md:text-9xl whitespace-nowrap bg-clip-text ">
+      <h1 className="py-3.5 px-0.5 z-10 text-4xl text-transparent duration-1000 bg-white cursor-default text-edge-outline animate-title font-display sm:text-6xl md:text-9xl whitespace-nowrap bg-clip-text ">
         chronark
       </h1>
 


### PR DESCRIPTION
Add padding to title for descenders.
Descenders are parts of a character that lie below the baseline.
Without padding, p, y, g and j are chopped. 
<img width="899" alt="Screenshot1" src="https://github.com/chronark/chronark.com/assets/155438264/751aea5d-c405-4ab2-b14c-d28bc05afaa0">
<img width="870" alt="Screenshot2" src="https://github.com/chronark/chronark.com/assets/155438264/5c9148dd-76fb-40e8-9672-d733971fa753">
