### PR TITLE
Precise view count

### DIFF
--- a/pages/api/incr.ts
+++ b/pages/api/incr.ts
@@ -39,7 +39,7 @@ export default async function incr(req: NextRequest): Promise<NextResponse> {
       ex: 24 * 60 * 60,
     });
     if (!isNew) {
-      new NextResponse(null, { status: 202 });
+      return new NextResponse(null, { status: 202 });
     }
   }
   await redis.incr(["pageviews", "projects", slug].join(":"));


### PR DESCRIPTION
This pull request includes a small but important change to the incr function in the pages/api/incr.ts file. The change ensures that the function correctly returns a response when a condition is met.

Added a return statement to ensure the function exits early with a 202 status response when the isNew condition is false. If there is no return statement await redis.incr(["pageviews", "projects", slug].join(":")); will get executed if new NextResponse(null, { status: 202 }); delays.