### PR TITLE
adding published field to props

### DIFF
--- a/app/projects/[slug]/header.tsx
+++ b/app/projects/[slug]/header.tsx
@@ -9,6 +9,7 @@ type Props = {
 		title: string;
 		description: string;
 		repository?: string;
+		published?: boolean;
 	};
 
 	views: number;


### PR DESCRIPTION
Adding published field to props since it exists in the contentlayer, but warning is displayed which says it is an invalid field