### PR TITLE
fix: add missing period in PR description guide

### DIFF
--- a/src/content/blog/on-writing-pr-descriptions.mdx
+++ b/src/content/blog/on-writing-pr-descriptions.mdx
@@ -34,7 +34,7 @@ It's usually not too hard to figure out *what* changed, you can just look at the
 
 Turning your mental model into complete sentences forces you to make your assumptions and reasoning explicit, which may reveal problems.
 
-- You can't clearly explain why you chose that approach. Maybe the LLM did a bit too much thinking and you just followed blindly? Chances are there's a better way to architect the solution
+- You can't clearly explain why you chose that approach. Maybe the LLM did a bit too much thinking and you just followed blindly? Chances are there's a better way to architect the solution.
 - You notice an assumption you haven't validated? Our product and team have grown over the years and it's hard to hold all that context in your head. There are plenty of assumptions we make each day, that might not be accurate anymore.
 - You discover an edge case you didn't see before.
 - You realise the change is solving a slightly different problem.


### PR DESCRIPTION
Fixes a minor punctuation typo in the "Writing Is the First Review" section.